### PR TITLE
Fix E474 error in minimap_buffer_enter_handler when opening minimap b…

### DIFF
--- a/autoload/minimap/vim.vim
+++ b/autoload/minimap/vim.vim
@@ -853,6 +853,9 @@ function! s:source_win_enter() abort
 endfunction
 
 function! s:minimap_buffer_enter_handler() abort
+    if empty(s:last_pos) || s:last_pos <= 0
+        return
+    endif
     " Move the cursor to where we were in the main buffer. Without this it
     " jumps to the top of the minimap
     call cursor(s:last_pos, 1)


### PR DESCRIPTION
This commit addresses an issue where the minimap plugin would throw an "E474: Invalid argument" error when Vim is opened without a file and the minimap buffer is focused. The error was caused by attempting to move the cursor to an invalid position.

The fix adds a condition to s:minimap_buffer_enter_handler() to ensure s:last_pos is not empty or less than or equal to zero before calling cursor().

This resolves the issue by preventing the cursor from moving to an invalid position.